### PR TITLE
Fix typo in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-grant docs
+graft docs
 include LICENSE*
 include pavement.py
 include TODO*


### PR DESCRIPTION
Currently there's this warning on install:
    warning: manifest_maker: MANIFEST.in, line 1: unknown action 'grant'
This change fixes it by changing it to 'graft'.
