### PR TITLE
FIX: Ignore errors when decoding to utf-8

### DIFF
--- a/easyprocess/unicodeutil.py
+++ b/easyprocess/unicodeutil.py
@@ -60,5 +60,5 @@ def unidecode(s):
         s = s.decode()
     else:
         if isinstance(s, str):
-            s = s.decode('utf-8')
+            s = s.decode('utf-8', 'ignore')
     return s


### PR DESCRIPTION
Some commands we handle with EasyProcess do not generate valid utf-8 output => EasyProcess crash when trying to decode stdout in utf-8.
Fix it by ignoring decoding errors