### PR TITLE
Replaces deprecated isAlive() with is_alive()

### DIFF
--- a/easyprocess/__init__.py
+++ b/easyprocess/__init__.py
@@ -275,7 +275,7 @@ class EasyProcess(object):
 
         if self._thread:
             self._thread.join(timeout=timeout)
-            self.timeout_happened = self.timeout_happened or self._thread.isAlive()
+            self.timeout_happened = self.timeout_happened or self._thread.is_alive()
         else:
             # no timeout and no existing thread
             self._wait4process()


### PR DESCRIPTION
This has been the new syntax since 2.6.

Fixes:

    /build/python-easyprocess/src/EasyProcess-0.2.10/build/lib/easyprocess/__init__.py:278: DeprecationWarning: isAlive() is deprecated, use is_alive() instead
    self.timeout_happened = self.timeout_happened or self._thread.isAlive()