### PR TITLE
Option to timeout and/or force kill a process on stop()

### DIFF
--- a/easyprocess/__init__.py
+++ b/easyprocess/__init__.py
@@ -278,7 +278,7 @@ class EasyProcess(object):
             if self.enable_stderr_log:
                 log.debug("stderr=%s", self.stderr)
 
-    def stop(self, kill_after=None):
+    def stop(self, timeout=None, kill_after=None):
         """Kill process and wait for command to complete.
 
         same as:
@@ -288,8 +288,8 @@ class EasyProcess(object):
         :rtype: self
 
         """
-        self.sendstop().wait(timeout=kill_after)
-        if self.is_alive():
+        self.sendstop().wait(timeout=kill_after or timeout)
+        if self.is_alive() and kill_after is not None:
             self.sendstop(kill=True).wait()
         return self
 
@@ -306,7 +306,8 @@ class EasyProcess(object):
         log.debug('stopping process (pid=%s cmd="%s")', self.pid, self.cmd)
         if self.popen:
             if self.is_alive():
-                log.debug("process is active -> sending SIGTERM")
+                signame = "SIGKILL" if kill else "SIGTERM"
+                log.debug("process is active -> sending " + signame)
 
                 try:
                     try:

--- a/tests/test_fast/test_timeout.py
+++ b/tests/test_fast/test_timeout.py
@@ -1,4 +1,6 @@
 import sys
+import os
+import time
 
 import pytest
 
@@ -74,3 +76,28 @@ def test_timeout_out():
 @pytest.mark.timeout(0.3)
 def test_time3():
     EasyProcess("sleep 5").start()
+
+
+ignore_term = """
+import signal;
+import time;
+signal.signal(signal.SIGTERM, lambda *args: None);
+while True:
+    time.sleep(0.5);
+"""
+
+
+@pytest.mark.timeout(3)
+def test_force_timeout():
+    proc = EasyProcess(["python", "-c", ignore_term]).start()
+    time.sleep(1)
+    proc.stop(kill_after=1)
+    assert proc.is_alive() is False
+    assert proc.return_code != 0
+
+
+@pytest.mark.timeout(3)
+def test_force_timeout2():
+    proc = EasyProcess(["python", "-c", ignore_term]).call(timeout=1, kill_after=1)
+    assert proc.is_alive() is False
+    assert proc.return_code != 0

--- a/tests/test_fast/test_timeout.py
+++ b/tests/test_fast/test_timeout.py
@@ -90,6 +90,10 @@ while True:
 @pytest.mark.timeout(3)
 def test_force_timeout():
     proc = EasyProcess(["python", "-c", ignore_term]).start()
+    # Calling stop() right away actually stops python before it
+    # has a change to actually compile and run the input code,
+    # meaning the signal handlers aren't registered yet. Give it
+    # a moment to setup
     time.sleep(1)
     proc.stop(kill_after=1)
     assert proc.is_alive() is False
@@ -99,5 +103,16 @@ def test_force_timeout():
 @pytest.mark.timeout(3)
 def test_force_timeout2():
     proc = EasyProcess(["python", "-c", ignore_term]).call(timeout=1, kill_after=1)
+    assert proc.is_alive() is False
+    assert proc.return_code != 0
+
+
+@pytest.mark.timeout(4)
+def test_stop_wait():
+    proc = EasyProcess(["python", "-c", ignore_term]).start()
+    time.sleep(1)
+    proc.stop(timeout=1)
+    assert proc.is_alive() is True
+    proc.stop(kill_after=1)
     assert proc.is_alive() is False
     assert proc.return_code != 0

--- a/tests/test_fast/test_timeout.py
+++ b/tests/test_fast/test_timeout.py
@@ -112,7 +112,13 @@ def test_stop_wait():
     proc = EasyProcess(["python", "-c", ignore_term]).start()
     time.sleep(1)
     proc.stop(timeout=1)
-    assert proc.is_alive() is True
+    # On windows, Popen.terminate actually behaves like kill,
+    # so don't check that our hanging process code is actually hanging.
+    # The end result is still what we want. On other platforms, leave
+    # this assertion to make sure we are correctly testing the ability
+    # to stop a hung process
+    if not sys.platform.startswith("win"):
+        assert proc.is_alive() is True
     proc.stop(kill_after=1)
     assert proc.is_alive() is False
     assert proc.return_code != 0


### PR DESCRIPTION
Currently `stop()` will always wait indefinitely for the child process to end. I've hit a few cases where a process sometimes gets hung and doesn't respond to SIGTERM which leaves the parent process waiting forever. There are ways around this by spawning of another thread to do the wait in the parent process manually, or by manually calling `sendstop()`/`wait(timeout)` but it would be nice to have a built in way to handle this scenario.

This adds a `kill_after` option to `call()` and `stop()` that will send a `SIGKILL` after the specified number of seconds if the process still hasn't stopped.

It also adds a regular `timeout` option to `stop()` so control can return to the parent process without necessarily killing the child proc.